### PR TITLE
Update Buildkite pipeline for the new JuliaGPU cluster

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ steps:
   - label: "Triggering Pipelines (Pull Request)"
     if: build.branch != "main" && build.tag == null
     agents:
-      queue: "juliagpu"
+      queue: "cuda"
     plugins:
       - monebag/monorepo-diff#v2.5.9:
           diff: ".buildkite/scripts/diff.sh $BUILDKITE_COMMIT"
@@ -17,10 +17,10 @@ steps:
               config:
                 command: "buildkite-agent pipeline upload .buildkite/testing.yml"
                 agents:
-                  queue: "juliagpu"
+                  queue: "cuda"
 
   - label: "Triggering Pipelines (Main Branch / Tag)"
     if: build.branch == "main" || build.tag != null
     agents:
-      queue: "juliagpu"
+      queue: "cuda"
     command: "buildkite-agent pipeline upload .buildkite/testing.yml"

--- a/.buildkite/testing.yml
+++ b/.buildkite/testing.yml
@@ -13,8 +13,7 @@ steps:
                 - src
                 - ext
         agents:
-          queue: "juliagpu"
-          cuda: "*"
+          queue: "cuda"
         if: build.message !~ /\[skip tests\]/ && build.message !~ /\[skip ci\]/
         timeout_in_minutes: 120
         matrix:
@@ -45,8 +44,7 @@ steps:
   #         JULIA_AMDGPU_HIP_MUST_LOAD: "1"
   #         JULIA_AMDGPU_DISABLE_ARTIFACTS: "1"
   #       agents:
-  #         queue: "juliagpu"
-  #         rocm: "*"
+  #         queue: "rocm"
   #         rocmgpu: "*"
   #       if: build.message !~ /\[skip tests\]/ && build.message !~ /\[skip ci\]/
   #       timeout_in_minutes: 60


### PR DESCRIPTION
The JuliaGPU Buildkite agents have moved to a dedicated cluster, where the single `juliagpu` queue has been split into per-backend queues. Steps now select agents using `queue: "cuda"`, `queue: "rocm"` or `queue: "oneapi"` instead of `queue: "juliagpu"` combined with a `cuda`/`rocm`/`intel` tag. The pipeline-upload trigger steps in `pipeline.yml`, which previously targeted the generic `juliagpu` queue without a backend tag, now run on the `cuda` queue. The commented-out AMDGPU group was updated as well.

This change only affects agent selection; the steps themselves are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)