### PR TITLE
ci: add Julia Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
+enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -15,3 +16,11 @@ updates:
     groups:
       documentation-node-dependencies:
         patterns: ["*"]
+  - package-ecosystem: "julia"
+    directories:
+      # Location of Julia projects
+      - "/"
+      - "/docs"
+      - "/test"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## What changed\n\nAdds weekly Dependabot updates for Julia projects at the repository root, docs, and test directories.\n\n## Why\n\nKeeps Julia package dependencies current, matching the Dependabot setup used by Lux.jl.\n\n## Validation\n\n- 